### PR TITLE
circe-jawn instead of circe-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val toolkit = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "cats-effect" % "3.4.8",
       "co.fs2" %%% "fs2-io" % "3.6.1",
       "org.http4s" %%% "http4s-ember-client" % "0.23.18",
-      "io.circe" %%% "circe-core" % "0.14.4",
+      "io.circe" %%% "circe-jawn" % "0.14.4",
       "org.http4s" %%% "http4s-circe" % "0.23.18",
       "com.monovore" %%% "decline-effect" % "2.4.1",
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3" // not % Test, on purpose :)


### PR DESCRIPTION
The parser is in `circe-jawn`, so we need that :)