### PR TITLE
Added point about building native image with --no-fallback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,10 @@ object Hello extends IOApp.Simple {
   def run = IO.println("Hello toolkit!")
 }
 ```
+
+### Native Image
+When building GraalVM Native Image the --no-fallback option is required, otherwise native-image will try searching a static reflection configuration for [this Enumeration method]. Thus using this flag is safe only if you're not using Enumerations in your codebase, see [this comment] for more info.
+
 @:@
 
 [Scala CLI]: https://scala-cli.virtuslab.org/
@@ -64,3 +68,6 @@ object Hello extends IOApp.Simple {
 [Circe]: https://circe.github.io/circe/
 [Decline Effect]: https://ben.kirw.in/decline/effect.html
 [Munit Cats Effect]: https://github.com/typelevel/munit-cats-effect
+
+[this Enumeration method]: https://github.com/scala/scala/blob/v2.13.8/src/library/scala/Enumeration.scala#L190-L215=
+[this comment]: https://github.com/typelevel/cats-effect/issues/3051#issuecomment-1167026949

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,13 +51,15 @@ object Hello extends IOApp.Simple {
   def run = IO.println("Hello toolkit!")
 }
 ```
-
-### Native Image
-When building GraalVM Native Image the --no-fallback option is required, otherwise native-image will try searching a static reflection configuration for [this Enumeration method]. Thus using this flag is safe only if you're not using Enumerations in your codebase, see [this comment] for more info.
-
 @:@
 
-[Scala CLI]: https://scala-cli.virtuslab.org/
+### Native Image
+
+When building GraalVM Native Image the --no-fallback option is required, otherwise native-image will try searching
+a static reflection configuration for [this Enumeration method]. Thus using this flag is safe only if you're not using
+Enumerations in your codebase, see [this comment] for more info.
+
+[Scala CLI]: https://scala-cli.virtuslab.org/_
 [Scala Toolkit]: https://github.com/VirtusLab/toolkit
 [Cats]: https://typelevel.org/cats
 [Cats Effect]: https://typelevel.org/cats-effect


### PR DESCRIPTION
Toolkit is great when building CLI applications as it adds pretty much all the functionality you might need. Native image is great for building CLI applications because of the quick startup. It does however not work with CE without the --no-fallback option. To stop users being confused by the image not working with a not obvious error message I figure it would be good to add a quick little info at the bottom here. Can probably be moved to a separate page when the docs are more fleshed out. The text i stolen from the CE documentation https://typelevel.org/cats-effect/docs/core/native-image