### PR TITLE
Separating the test artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p toolkit/js/target target toolkit/native/target .js/target site/target toolkit/jvm/target .jvm/target .native/target project/target
+        run: mkdir -p toolkit/js/target toolkit-test/jvm/target toolkit-test/native/target target toolkit/native/target .js/target toolkit-test/js/target site/target toolkit/jvm/target .jvm/target .native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar toolkit/js/target target toolkit/native/target .js/target site/target toolkit/jvm/target .jvm/target .native/target project/target
+        run: tar cf targets.tar toolkit/js/target toolkit-test/jvm/target toolkit-test/native/target target toolkit/native/target .js/target toolkit-test/js/target site/target toolkit/jvm/target .jvm/target .native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,3 +34,11 @@ pull_request_rules:
       add:
       - toolkit
       remove: []
+- name: Label toolkit-test PRs
+  conditions:
+  - files~=^toolkit-test/
+  actions:
+    label:
+      add:
+      - toolkit-test
+      remove: []

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ lazy val toolkitTest = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "toolkit-test",
     libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % "2.9.0",
+      "org.typelevel" %%% "cats-effect-testkit" % "3.5.0",
       "org.scalameta" %%% "munit" % "1.0.0-M7", // not % Test, on purpose :)
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / mergifyStewardConfig ~= {
 
 ThisBuild / crossScalaVersions := Seq("2.13.10", "3.2.2")
 
-lazy val root = tlCrossRootProject.aggregate(toolkit)
+lazy val root = tlCrossRootProject.aggregate(toolkit, toolkitTest)
 
 lazy val toolkit = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("toolkit"))
@@ -26,7 +26,16 @@ lazy val toolkit = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.http4s" %%% "http4s-ember-client" % "0.23.19",
       "io.circe" %%% "circe-jawn" % "0.14.5",
       "org.http4s" %%% "http4s-circe" % "0.23.19",
-      "com.monovore" %%% "decline-effect" % "2.4.1",
+      "com.monovore" %%% "decline-effect" % "2.4.1"
+    ),
+    mimaPreviousArtifacts := Set()
+  )
+
+lazy val toolkitTest = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .in(file("toolkit-test"))
+  .settings(
+    name := "toolkit-test",
+    libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % "1.0.0-M7", // not % Test, on purpose :)
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3"
     ),

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,16 @@ To use it with [Scala CLI] use this directive:
 
 Albeit being created to be used with [Scala CLI], typelevel-toolkit can be imported into your `build.sbt` using:
 ```scala
-libraryDependencies += "org.typelevel" %% "toolkit" % "@VERSION@"
-// for native and js
-libraryDependencies += "org.typelevel" %%% "toolkit" % "@VERSION@"
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "toolkit" % "@VERSION@",
+  "org.typelevel" %% "toolkit-test" % "@VERSION@" % Test
+)
+
+// use %%% for Scala.js and Scala Native
+libraryDependencies ++= Seq(
+  "org.typelevel" %%% "toolkit" % "@VERSION@",
+  "org.typelevel" %%% "toolkit-test" % "@VERSION@" % Test
+)
 ```
 
 ## Quick Start Example


### PR DESCRIPTION
~~I'll leave this in draft for now:~~ Nvm, I opened it as a standard PR by mistake :P

It's a test, and we need to check whether maven central will need some mangling to let us upload the artifact.

Also, one thing to note is that `toolkit-test` doesn't depend on `toolkit`. This was done due to [some discussions in the toolkit repo](https://github.com/VirtusLab/scala-cli/issues/2060). 
TLDR: the behaviour should be that scala-cli will add **both** the artifacts if the directive `//> using test.toolkit latest` is used in a test file.

Lastly, the site will need some updates to mention the 2 artifacts and instructions if this gets merged.

Closes #30.