### PR TITLE
Update toolkit readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A toolkit of great libraries to get started building Typelevel apps on JVM, Node.js, and Native! Our very own flavour of the [Scala Toolkit].
 
 ```scala
-//> using lib "org.typelevel::toolkit::latest.release"
+//> using toolkit typelevel:latest
 
 import cats.effect.*
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ object Hello extends IOApp.Simple:
   def run = IO.println("Hello toolkit!")
 ```
 
-It currently includes:
+To get started, you can use the accompanying [template](https://github.com/typelevel/toolkit.g8) :
+
+``` sh
+scala-cli --power new typelevel/toolkit.g8
+```
+
+# Libraries included
 
 * [Cats] and [Cats Effect]
 * [FS2] and [FS2 I/O]

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ and it's published for Scala 2.12, 2.13 and 3.2.2.
 
 To use it with [Scala CLI] use this directive:
 ```scala
-//> using lib "org.typelevel::toolkit::@VERSION@"
+//> using toolkit typelevel:latest
 ```
 
 Albeit being created to be used with [Scala CLI], typelevel-toolkit can be imported into your `build.sbt` using:
@@ -37,11 +37,20 @@ libraryDependencies ++= Seq(
 )
 ```
 
-## Quick Start Example
+## Quick Start
+
+Getting started with the toolkit is as simple as running a single command:
+
+```sh
+scala-cli --power new typelevel/toolkit.g8
+```
+
+## Example
+
 @:select(scala-version)
 @:choice(scala-3)
 ```scala mdoc:reset:silent
-//> using lib "org.typelevel::toolkit::@VERSION@"
+//> using toolkit typelevel:latest
 
 import cats.effect.*
 
@@ -50,7 +59,7 @@ object Hello extends IOApp.Simple:
 ```
 @:choice(scala-2)
 ```scala mdoc:reset:silent
-//> using lib "org.typelevel::toolkit::@VERSION@"
+//> using toolkit typelevel:latest
 
 import cats.effect._
 


### PR DESCRIPTION
I updated the toolkit directive in the docs too, since 1.0 this directive is supported: https://github.com/VirtusLab/scala-cli/releases/tag/v1.0.0