### PR TITLE
Update deps, refresh build, support Scala Native 0.5!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
           path: targets.tar
@@ -107,7 +107,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -128,7 +128,7 @@ jobs:
         run: sbt +update
 
       - name: Download target directories (2.13, rootJS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootJS
 
@@ -138,7 +138,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13, rootJVM)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootJVM
 
@@ -148,7 +148,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13, rootNative)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootNative
 
@@ -158,7 +158,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, rootJS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJS
 
@@ -168,7 +168,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, rootJVM)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJVM
 
@@ -178,7 +178,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, rootNative)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootNative
 
@@ -221,7 +221,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -231,7 +231,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -244,7 +244,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: rootjs_2.13 rootjs_3 docs_3 tests_sjs1_2.13 tests_sjs1_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 tests_2.13 tests_3 tests_native0.4_2.13 tests_native0.4_3
+          modules-ignore: rootjs_2.13 rootjs_3 docs_3 tests_sjs1_2.13 tests_sjs1_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 tests_2.13 tests_3 tests_native0.5_2.13 tests_native0.5_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:
@@ -256,7 +256,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -266,7 +266,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.9.4
+version = 3.10.7
 runner.dialect = scala213
 
 fileOverride {

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ To get started, you can use the accompanying [template](https://github.com/typel
 scala-cli --power new typelevel/toolkit.g8
 ```
 
-> [!IMPORTANT]
-> The toolkit does not yet support Scala Native 0.5.x series.
-
 # Libraries included
 
 * [Cats] and [Cats Effect]

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / mergifyStewardConfig ~= {
   _.map(_.withAuthor("typelevel-steward[bot]"))
 }
 
-ThisBuild / crossScalaVersions := Seq("2.13.16", "3.3.5")
+ThisBuild / crossScalaVersions := Seq("2.13.18", "3.3.7")
 
 lazy val root = tlCrossRootProject
   .aggregate(toolkit, toolkitTest, tests)
@@ -20,15 +20,15 @@ lazy val toolkit = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "toolkit",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core" % "2.11.0",
-      "org.typelevel" %%% "cats-effect" % "3.6.1",
-      "co.fs2" %%% "fs2-io" % "3.11.0",
-      "org.gnieh" %%% "fs2-data-csv" % "1.11.3",
-      "org.gnieh" %%% "fs2-data-csv-generic" % "1.11.3",
-      "org.http4s" %%% "http4s-ember-client" % "0.23.30",
-      "io.circe" %%% "circe-jawn" % "0.14.8",
-      "org.http4s" %%% "http4s-circe" % "0.23.30",
-      "com.monovore" %%% "decline-effect" % "2.4.1"
+      "org.typelevel" %%% "cats-core" % "2.13.0",
+      "org.typelevel" %%% "cats-effect" % "3.7.0",
+      "co.fs2" %%% "fs2-io" % "3.13.0",
+      "org.gnieh" %%% "fs2-data-csv" % "1.13.0",
+      "org.gnieh" %%% "fs2-data-csv-generic" % "1.13.0",
+      "org.http4s" %%% "http4s-ember-client" % "0.23.34",
+      "io.circe" %%% "circe-jawn" % "0.14.14",
+      "org.http4s" %%% "http4s-circe" % "0.23.34",
+      "com.monovore" %%% "decline-effect" % "2.6.2"
     ),
     mimaPreviousArtifacts := Set()
   )
@@ -38,10 +38,10 @@ lazy val toolkitTest = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "toolkit-test",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core" % "2.11.0",
-      "org.typelevel" %%% "cats-effect-testkit" % "3.6.1",
-      "org.scalameta" %%% "munit" % "1.0.0", // not % Test, on purpose :)
-      "org.typelevel" %%% "munit-cats-effect" % "2.0.0"
+      "org.typelevel" %%% "cats-core" % "2.13.0",
+      "org.typelevel" %%% "cats-effect-testkit" % "3.7.0",
+      "org.scalameta" %%% "munit" % "1.3.0", // not % Test, on purpose :)
+      "org.typelevel" %%% "munit-cats-effect" % "2.2.0"
     ),
     mimaPreviousArtifacts := Set()
   )
@@ -51,12 +51,11 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := "tests",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "munit-cats-effect" % "2.0.0" % Test,
-      "co.fs2" %%% "fs2-io" % "3.11.0" % Test,
-      "org.virtuslab.scala-cli" %% "cli" % "1.5.4" cross (CrossVersion.for2_13Use3)
+      "org.typelevel" %%% "munit-cats-effect" % "2.2.0" % Test,
+      "co.fs2" %%% "fs2-io" % "3.13.0" % Test,
+      "org.virtuslab.scala-cli" %% "cli" % "1.12.5" cross (CrossVersion.for2_13Use3)
     ),
     buildInfoKeys += scalaBinaryVersion,
-    buildInfoKeys += "nativeVersion" -> nativeVersion,
     buildInfoKeys += BuildInfoKey.map(Compile / dependencyClasspath) {
       case (_, v) =>
         "classPath" -> v.seq

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "munit-cats-effect" % "2.2.0" % Test,
       "co.fs2" %%% "fs2-io" % "3.13.0" % Test,
-      "org.virtuslab.scala-cli" %% "cli" % "1.12.5" cross (CrossVersion.for2_13Use3)
+      "org.virtuslab.scala-cli" %% "cli" % "1.13.0" cross (CrossVersion.for2_13Use3)
     ),
     buildInfoKeys += scalaBinaryVersion,
     buildInfoKeys += BuildInfoKey.map(Compile / dependencyClasspath) {

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val toolkitTest = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.scalameta" %%% "munit" % "1.3.0", // not % Test, on purpose :)
       "org.typelevel" %%% "munit-cats-effect" % "2.2.0"
     ),
+    libraryDependencySchemes += "org.scala-native" %% "test-interface_native0.5" % VersionScheme.Always,
     mimaPreviousArtifacts := Set()
   )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,6 @@ A toolkit of **great libraries** to start building **Typelevel** apps on JVM, No
 
 Our very own flavour of the [Scala Toolkit].
 
-@:callout(info)
-
-The toolkit does not yet support Scala Native 0.5.x series.
-
-@:@
-
 ## Overview
 
 Typelevel toolkit is a meta library that currently includes these libraries:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.12.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-val sbtTlVersion = "0.7.7"
+val sbtTlVersion = "0.8.5"
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTlVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-mergify" % sbtTlVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTlVersion)
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")

--- a/tests/shared/src/test/scala/org/typelevel/toolkit/ScalaCliProcess.scala
+++ b/tests/shared/src/test/scala/org/typelevel/toolkit/ScalaCliProcess.scala
@@ -40,7 +40,7 @@ object ScalaCliProcess {
         process.stdout.through(fs2.text.utf8.decode).compile.string,
         process.stderr.through(fs2.text.utf8.decode).compile.string
       ).parFlatMapN {
-        case (0, _, _) => IO.unit
+        case (0, _, _)                  => IO.unit
         case (exitCode, stdout, stdErr) =>
           val errorMessage: String = List(
             Option(stdout).filter(_.nonEmpty).map(s => s"[STDOUT]: $s"),
@@ -67,18 +67,11 @@ object ScalaCliProcess {
         None
       )
       .evalTap { path =>
-        val commonHeader = List(
+        val header = List(
           s"//> using scala ${BuildInfo.scalaBinaryVersion}",
           s"//> using toolkit typelevel:${BuildInfo.version}",
           s"//> using platform ${BuildInfo.platform}"
         )
-        val header = BuildInfo.platform match {
-          case "jvm" => commonHeader
-          case "js"  => commonHeader
-          case "native" =>
-            commonHeader :+
-              s"//> using nativeVersion ${BuildInfo.nativeVersion}"
-        }
         Stream(header.mkString("", "\n", "\n"), scriptBody.stripMargin)
           .through(Files[IO].writeUtf8(path))
           .compile


### PR DESCRIPTION
Towards https://github.com/typelevel/toolkit/issues/171. This is very very close, we just need a new scala-cli release with https://github.com/VirtusLab/scala-cli/pull/4229.