### PR TITLE
Remove Scala Native caveats from documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,36 +69,6 @@ object Hello extends IOApp.Simple {
 ```
 @:@
 
-### Scala Native usage
-
-Since the native flavour of most of the **Typelevel libraries** is, at the moment, built against Scala Native 0.4.15, when using [Scala CLI] you have to declare the Scala native's version, i.e.
-
-@:select(scala-version)
-@:choice(scala-3)
-```scala mdoc:reset:silent
-//> using toolkit typelevel:default
-//> using platform native
-//> using nativeVersion 0.4.15
-
-import cats.effect.*
-
-object Hello extends IOApp.Simple:
-  def run = IO.println("Hello toolkit!")
-```
-@:choice(scala-2)
-```scala mdoc:reset:silent
-//> using toolkit typelevel:default
-//> using platform native
-//> using nativeVersion 0.4.17
-
-import cats.effect._
-
-object Hello extends IOApp.Simple {
-  def run = IO.println("Hello toolkit!")
-}
-```
-@:@
-
 ## Native Image
 
 When building GraalVM Native Image the `--no-fallback` option is required, otherwise native-image will try searching


### PR DESCRIPTION
This caveat about Scala Native 0.4 is no longer needed :)